### PR TITLE
Upgrade Elixir and Erlang versions

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,5 +1,5 @@
 # Development Dockerfile for Mediate Elixir/Phoenix Application
-FROM hexpm/elixir:1.17.2-erlang-27.0.1-ubuntu-jammy-20240808
+FROM hexpm/elixir:1.18.3-erlang-27.3.3-ubuntu-jammy-20240808
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -37,8 +37,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        otp-version: 26.0.2
-        elixir-version: 1.15.4
+        otp-version: 27.3.3
+        elixir-version: 1.18.3
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.2-otp-27
-erlang 27.0.1
+elixir 1.18.3-otp-27
+erlang 27.3.3

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mediate.MixProject do
     [
       app: :mediate,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Upgrade Elixir to 1.18.3-otp-27 and Erlang to 27.3.3, updating all relevant version references.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dd61a93-c9b3-4f0a-af03-bff04c297257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5dd61a93-c9b3-4f0a-af03-bff04c297257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>