### PR TITLE
Configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"
+
+  - package-ecosystem: "docker"
+    directory: "/.cursor"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"


### PR DESCRIPTION
## Summary
- add Dependabot config for Mix, Docker, and GitHub Actions
- group dependency updates into one weekly PR
- request dewetblomerus as reviewer