### PR TITLE
Bump Elixir to 1.19.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.3-otp-27
-erlang 27.3.3
+elixir 1.19.5-otp-28
+erlang 28.5

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mediate.MixProject do
     [
       app: :mediate,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Bumps the app to the shared Elixir v1 tuple:

- Elixir 1.19.5
- Erlang/OTP 28.5
- Docker OTP 28.5.0.1
- Debian trixie-20260518-slim